### PR TITLE
move jzmmc_v12 into a module with supporting changes

### DIFF
--- a/arch/mips/xburst/soc-t20/chip-t20/isvp/bull/board.h
+++ b/arch/mips/xburst/soc-t20/chip-t20/isvp/bull/board.h
@@ -34,7 +34,7 @@
 /* ****************************GPIO MMC START******************************** */
 #define GPIO_MMC_RST_N			-1
 #define GPIO_MMC_RST_N_LEVEL	LOW_ENABLE
-#define GPIO_MMC_CD_N			GPIO_PB(27)
+#define GPIO_MMC_CD_N			-1
 #define GPIO_MMC_CD_N_LEVEL		LOW_ENABLE
 #define GPIO_MMC_PWR			-1
 #define GPIO_MMC_PWR_LEVEL		HIGH_ENABLE

--- a/arch/mips/xburst/soc-t20/common/gpio.c
+++ b/arch/mips/xburst/soc-t20/common/gpio.c
@@ -280,6 +280,7 @@ int jz_gpio_set_func(int gpio, enum gpio_function func)
 	gpio_set_func(jz, func, pin);
 	return 0;
 }
+EXPORT_SYMBOL(jz_gpio_set_func);
 
 int jzgpio_ctrl_pull(enum gpio_port port, int enable_pull,unsigned long pins)
 {
@@ -861,10 +862,6 @@ int __init setup_gpio_pins(void)
 		}
 		if (!strcmp(g->name,"msc1-pC") && !disable_gmac){
 			pr_info("Skipping MSC1_PC GPIO setup\n");
-			continue;
-		}
-		if ((!strcmp(g->name,"wyze-mmc-enable") || !strcmp(g->name,"wyze-mmc-detect")) && !disable_gmac){
-			pr_info("Skipping WYZE GPIO setup\n");
 			continue;
 		}
 

--- a/arch/mips/xburst/soc-t20/include/mach/platform.h
+++ b/arch/mips/xburst/soc-t20/include/mach/platform.h
@@ -21,9 +21,7 @@
 #define MSC0_PORTB_4BIT							\
 	{ .name = "msc0-pb-4bit",	.port = GPIO_PORT_B, .func = GPIO_FUNC_0, .pins = (0x3<<4|0xf<<0), }
 #define MSC1_PORTC							\
-	{ .name = "msc1-pC",		.port = GPIO_PORT_C, .func = GPIO_FUNC_0, .pins = (0x3f<<2), }, \
-	{ .name = "wyze-mmc-enable",	.port = GPIO_PORT_B, .func = GPIO_OUTPUT0, .pins = 0x620<<10, }, \
-	{ .name = "wyze-mmc-detect",	.port = GPIO_PORT_B, .func = GPIO_OUTPUT1, .pins = 0x20<<10, }
+	{ .name = "msc1-pC",		.port = GPIO_PORT_C, .func = GPIO_FUNC_0, .pins = (0x3f<<2), }
 
 /*******************************************************************************************************************/
 /*****************************************************************************************************************/

--- a/arch/mips/xburst/soc-t31/chip-t31/isvp/Swan/board.h
+++ b/arch/mips/xburst/soc-t31/chip-t31/isvp/Swan/board.h
@@ -32,7 +32,7 @@
 /* ****************************GPIO MMC START******************************** */
 #define GPIO_MMC_RST_N			-1
 #define GPIO_MMC_RST_N_LEVEL	LOW_ENABLE
-#define GPIO_MMC_CD_N			GPIO_PB(27)
+#define GPIO_MMC_CD_N			-1
 #define GPIO_MMC_CD_N_LEVEL		LOW_ENABLE
 #define GPIO_MMC_PWR			-1
 #define GPIO_MMC_PWR_LEVEL		HIGH_ENABLE

--- a/arch/mips/xburst/soc-t31/chip-t31/isvp/Swan/gpio_customized.c
+++ b/arch/mips/xburst/soc-t31/chip-t31/isvp/Swan/gpio_customized.c
@@ -14,7 +14,8 @@ typedef struct gpio_drive_strength_table {
 } gpio_drive_strength_table_t;
 
 static gpio_pull_table_t soc_gpio_pull_table[] = {
-	{ GPIO_PB(27), GPIO_PULL_UP }, //TF cd
+// Dont force the pull state of the GPIO since we may not be using it for the TF cd pin
+//	{ GPIO_PB(27), GPIO_PULL_UP }, //TF cd
 };
 
 static gpio_drive_strength_table_t soc_gpio_drive_strength_table[] = {

--- a/arch/mips/xburst/soc-t31/common/gpio.c
+++ b/arch/mips/xburst/soc-t31/common/gpio.c
@@ -354,6 +354,7 @@ int jz_gpio_set_func(int gpio, enum gpio_function func)
 	gpio_set_func(jz, func, pin);
 	return 0;
 }
+EXPORT_SYMBOL(jz_gpio_set_func);
 
 void jz_gpio_set_drive_strength(int gpio, gpio_drv_level_t lvl)
 {

--- a/arch/mips/xburst/soc-t31/common/gpio.c
+++ b/arch/mips/xburst/soc-t31/common/gpio.c
@@ -991,10 +991,6 @@ int __init setup_gpio_pins(void)
 			pr_info("Skipping MSC1_PB GPIO setup\n");
 			continue;
 		}
-		if ((!strcmp(g->name,"wyze-mmc-enable") || !strcmp(g->name,"wyze-mmc-detect")) && !disable_gmac){
-			pr_info("Skipping WYZE GPIO setup\n");
-			continue;
-		}
 
 		jz = &jz_gpio_chips[g->port];
 		if (GPIO_AS_FUNC(g->func)) {

--- a/arch/mips/xburst/soc-t31/include/mach/platform.h
+++ b/arch/mips/xburst/soc-t31/include/mach/platform.h
@@ -23,9 +23,7 @@
 #define MSC0_PORTB_4BIT							\
 	{ .name = "msc0-pb-4bit",	.port = GPIO_PORT_B, .func = GPIO_OUTPUT0, .pins = (0x3f<<0), }
 #define MSC1_PORTB							\
-	{ .name = "msc1-pB",		.port = GPIO_PORT_B, .func = GPIO_FUNC_1, .pins = (0x6f<<8), }, \
-	{ .name = "wyze-mmc-enable",	.port = GPIO_PORT_B, .func = GPIO_OUTPUT0, .pins = 0x8000, }, \
-	{ .name = "wyze-mmc-detect",	.port = GPIO_PORT_B, .func = GPIO_OUTPUT1, .pins = 0x40000000, }
+	{ .name = "msc1-pB",		.port = GPIO_PORT_B, .func = GPIO_FUNC_1, .pins = (0x6f<<8), }
 #define MSC1_PORTC							\
 	{ .name = "msc1-pC",		.port = GPIO_PORT_C, .func = GPIO_FUNC_0, .pins = (0x3f<<2), }
 #define I2S_PORTC                           \

--- a/drivers/mmc/host/jzmmc_v12.c
+++ b/drivers/mmc/host/jzmmc_v12.c
@@ -34,6 +34,11 @@
 /**
  * MMC driver parameters
  */
+
+static int cd_gpio_pin = -1;
+module_param(cd_gpio_pin, int, 0644);
+MODULE_PARM_DESC(cd_gpio_pin, "Card Detect GPIO pin number");
+
 #define MAX_SEGS		128	/* max count of sg */
 #define TIMEOUT_PERIOD		500	/* msc operation timeout detect period */
 #define PIO_THRESHOLD		64	/* use pio mode if data length < PIO_THRESHOLD */
@@ -1628,6 +1633,8 @@ static int __init jzmmc_msc_init(struct jzmmc_host *host)
 	return ret;
 }
 
+static int host_count = 0;
+
 static int __init jzmmc_gpio_init(struct jzmmc_host *host)
 {
 	struct card_gpio *card_gpio = host->pdata->gpio;
@@ -1635,6 +1642,10 @@ static int __init jzmmc_gpio_init(struct jzmmc_host *host)
 	int cd_port, cd_pin;
 
 	jz_gpio_set_func(36, GPIO_OUTPUT0);
+
+	if (host_count == 0 && cd_gpio_pin >= 0) {
+		card_gpio->cd.num = cd_gpio_pin;
+	}
 
 	if (card_gpio) {
 		if (card_gpio->cd.num > 0)
@@ -1715,6 +1726,9 @@ static int __init jzmmc_gpio_init(struct jzmmc_host *host)
 		set_bit(JZMMC_CARD_PRESENT, &host->flags);
 		break;
 	}
+
+	// Increment the host count
+	host_count++;
 
 	return ret;
 }


### PR DESCRIPTION
Revert OpenIPC Patches for "wyze-mmc-*" Functions

- Reverted OpenIPC specific patches affecting "wyze-mmc-*" functions.
- Updated jzmmc_v12 driver for modular operation. This update is beneficial for devices that do not always require MMC devices. 
- The module now accepts a 'cd_gpio_pin=xx' parameter, allowing specification of the SD card CD pin.
- These updates enhance compatibility, especially for devices with motors, ensuring full utilization of all motor phases.
