### PR TITLE
add CONFIG_JZMMC_V12_MMC0_1BIT option

### DIFF
--- a/arch/mips/xburst/soc-t23/chip-t23/isvp/common/mmc.c
+++ b/arch/mips/xburst/soc-t23/chip-t23/isvp/common/mmc.c
@@ -23,7 +23,11 @@ struct jzmmc_platform_data tf_pdata = {
 	.removal  			= REMOVABLE,
 	.sdio_clk			= 1,
 	.ocr_avail			= MMC_VDD_32_33 | MMC_VDD_33_34,
+#ifdef CONFIG_JZMMC_V12_MMC0_1BIT
+	.capacity  			= MMC_CAP_SD_HIGHSPEED | MMC_CAP_MMC_HIGHSPEED,
+#else
 	.capacity  			= MMC_CAP_SD_HIGHSPEED | MMC_CAP_MMC_HIGHSPEED | MMC_CAP_4_BIT_DATA,
+#endif
 	.pm_flags			= 0,
 	.recovery_info			= NULL,
 	.gpio				= &tf_gpio,

--- a/drivers/mmc/host/Kconfig
+++ b/drivers/mmc/host/Kconfig
@@ -35,6 +35,15 @@ config JZMMC_V12_MMC0_PB_4BIT
 	bool "GPIO B, data with 4 bit"
 endchoice
 
+config JZMMC_V12_MMC0_1BIT
+    bool "Restrict host controller to 1 bit bus width"
+    default n
+    help
+      Some devices (Galayou G2 T23N) apparently do not support 4-bit data transfers.
+      Enabling this option will restrict the host to using just 1-bit data
+      transfers.
+      If unsure, say N.
+
 config MMC0_MAX_FREQ
 	int "msc0 max frequency"
 	depends on JZMMC_V12_MMC0


### PR DESCRIPTION
This option restricts the JZ MMC0 host controller to use only 1 bit, which is apparently what Galayou G2/T23n does.