### PR TITLE
fix erase size for chipid 0xc22017 (MX25L6406E)

### DIFF
--- a/arch/mips/xburst/soc-t10/chip-t10/isvp/common/spi_bus.c
+++ b/arch/mips/xburst/soc-t10/chip-t10/isvp/common/spi_bus.c
@@ -352,7 +352,7 @@ struct spi_nor_platform_data spi_nor_pdata[] = {
 		.pagesize = 256,
 		.sectorsize = 4 * 1024,
 		.chipsize = 8192 * 1024,
-		.erasesize = 32 * 1024,
+		.erasesize = 64 * 1024,
 		.id = 0xc22017,
 
 		.block_info = flash_block_info,


### PR DESCRIPTION
The Macronix MX25L6406E does not support 32K erases. The two erase commands 52h and d8h, erase 64k blocks. The issue manifests as flash corruption and writes to unrelated MTDs as the driver erases twice the data that is requested.

https://www.macronix.com/Lists/Datasheet/Attachments/8630/MX25L6406E,%203V,%2064Mb,%20v1.9.pdf