### PR TITLE
Fix mmc 1 remove also break mmc 0

### DIFF
--- a/drivers/mmc/host/jzmmc_v12.c
+++ b/drivers/mmc/host/jzmmc_v12.c
@@ -1287,7 +1287,8 @@ static inline void jzmmc_power_off(struct jzmmc_host *host)
 {
 	dev_vdbg(host->dev, "power_off\n");
 
-	jzgpio_set_func(GPIO_PORT_B, GPIO_OUTPUT0, 0x3f);
+	if (host->pdata->gpio)
+		jzgpio_set_func(GPIO_PORT_B, GPIO_OUTPUT0, 0x3f);
 	if (!IS_ERR(host->power)) {
 		if(regulator_is_enabled(host->power))
 			regulator_disable(host->power);


### PR DESCRIPTION
Currently send REMOVE to mmc 1 will break mmc 0. Also sending INSERT to mmc 1 while mmc1 is not connected/ powered on will also break mmc0 .
Gino says it will work. Tested, works.

## Why it happens

The call chain when you write INSERT/REMOVE to mmc1's sysfs:

1. `jzmmc_present_store()` → `mmc_detect_change()` → MMC core calls `jzmmc_set_ios()`
2. **INSERT** → `jzmmc_power_on()` → `jzgpio_set_func(GPIO_PORT_B, GPIO_FUNC_0, 0x3f)`
3. **REMOVE** → `jzmmc_power_off()` → `jzgpio_set_func(`, GPIO_OUTPUT0, 0x3f)`

Both hardcode **GPIO Port B, mask `0x3f`** (pins 0–5) — the shared MSC data bus. This is the same bus mmc0 uses.

### Why INSERT works with a real card but breaks without one:
- **Card present**: `power_on()` sets Port B to `FUNC_0` (MSC function) → correct state → card initializes → bus stays in FUNC_0 → mmc0 unaffected ✅
- **No card**: `power_on()` sets Port B to FUNC_0 (fine) → MMC core finds no card → calls `power_off()` → sets Port B to `OUTPUT0` (drive low) → **mmc0 data lines killed** 💀
- **REMOVE**: `power_off()` immediately sets Port B to `OUTPUT0` → **mmc0 data lines killed** 💀

## Fix: Kernel Patch

Since mmc1 (`sdio_pdata`) has `gpio = NULL` and `removal = MANUAL`, guard the Port B manipulation so only mmc0 (which has `gpio = &tf_gpio`) touches it:

This way:
| Host | `pdata->gpio` | Touches Port B? |
|------|--------------|-----------------|
| mmc0 (SD card) | `&tf_gpio` | ✅ Yes (normal behavior) |
| mmc1 (SDIO WiFi) | `NULL` | ❌ No (leaves mmc0 alone) |
